### PR TITLE
Fixes/integer choices greg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 .prod.dns.json
 
 .idea/
+manage.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY requirements.txt /app/
 
 RUN pip install -r requirements.txt
 
-COPY ./mobot /app/
+COPY src /app/
 COPY ./privacy /privacy/
 COPY ./docker/admin_start.sh /usr/local/bin/admin_start.sh
 COPY ./docker/mobot_client_start.sh /usr/local/bin/mobot_client_start.sh

--- a/RUN.md
+++ b/RUN.md
@@ -32,12 +32,10 @@ For testing, we build and run locally, using the Signal staging network, and the
 1. Set up and run full-service
 1. Run the MOBot
 
-#### Clone MOBot and Update the Submodule
+#### Clone MOBot
 
 1. ```shell
    git clone git@github.com:mobilecoinofficial/mobot.git
-   cd mobot
-   git  submodule update --init --recursive
    ```
 
 #### Set Up and Run Signald

--- a/src/mobot_client/air_drop_session.py
+++ b/src/mobot_client/air_drop_session.py
@@ -3,10 +3,10 @@
 import random
 
 from decimal import Decimal
-from mobot_client.drop_session import BaseDropSession, SessionState
+from mobot_client.drop_session import BaseDropSession
 from mobot_client.models import (
     DropSession,
-    BonusCoin,
+    BonusCoin, SessionState,
 )
 
 import mobilecoin as mc
@@ -78,13 +78,13 @@ class AirDropSession(BaseDropSession):
             self.messenger.log_and_send_message(
                 customer, source, ChatStrings.BYE
             )
-            drop_session.state = SessionState.COMPLETED.value
+            drop_session.state = SessionState.COMPLETED
             drop_session.save()
         else:
             self.messenger.log_and_send_message(
                 customer, source, ChatStrings.NOTIFICATIONS_ASK
             )
-            drop_session.state = SessionState.ALLOW_CONTACT_REQUESTED.value
+            drop_session.state = SessionState.ALLOW_CONTACT_REQUESTED
             drop_session.save()
 
     def handle_drop_session_waiting_for_bonus_transaction(self, message, drop_session):
@@ -125,17 +125,17 @@ class AirDropSession(BaseDropSession):
         )
 
     def handle_active_airdrop_drop_session(self, message, drop_session):
-        if drop_session.state == SessionState.READY_TO_RECEIVE_INITIAL.value:
+        if drop_session.state == SessionState.READY_TO_RECEIVE_INITIAL:
             self.handle_drop_session_ready_to_receive(message, drop_session)
             return
 
-        if drop_session.state == SessionState.WAITING_FOR_BONUS_TRANSACTION.value:
+        if drop_session.state == SessionState.WAITING_FOR_BONUS_TRANSACTION:
             self.handle_drop_session_waiting_for_bonus_transaction(
                 message, drop_session
             )
             return
 
-        if drop_session.state == SessionState.ALLOW_CONTACT_REQUESTED.value:
+        if drop_session.state == SessionState.ALLOW_CONTACT_REQUESTED:
             self.handle_drop_session_allow_contact_requested(message, drop_session)
             return
 
@@ -180,7 +180,7 @@ class AirDropSession(BaseDropSession):
         new_drop_session = DropSession(
             customer=customer,
             drop=drop,
-            state=SessionState.READY_TO_RECEIVE_INITIAL.value,
+            state=SessionState.READY_TO_RECEIVE_INITIAL,
         )
         new_drop_session.save()
 

--- a/src/mobot_client/air_drop_session.py
+++ b/src/mobot_client/air_drop_session.py
@@ -9,6 +9,7 @@ from mobot_client.models import (
     BonusCoin,
 )
 
+import mobilecoin as mc
 from mobot_client.chat_strings import ChatStrings
 
 

--- a/src/mobot_client/drop_session.py
+++ b/src/mobot_client/drop_session.py
@@ -1,70 +1,11 @@
 # Copyright (c) 2021 MobileCoin. All rights reserved.
 
-import enum
-
 import mobilecoin as mc
 from django.utils import timezone
-from django.db import models
 
-from mobot_client.models import DropSession, Drop, CustomerStorePreferences
+from mobot_client.models import DropSession, Drop, CustomerStorePreferences, ItemSessionState, SessionState
 
 from mobot_client.chat_strings import ChatStrings
-
-
-class SessionStateReadyToReceiveInitial(models.IntegerChoices):
-    NOT_READY = 0
-    READY = 1
-
-
-class SessionState(models.IntegerChoices):
-    CANCELLED = -1
-    READY_TO_RECEIVE_INITIAL = 0
-    WAITING_FOR_BONUS_TRANSACTION = 1
-    ALLOW_CONTACT_REQUESTED = 2
-    COMPLETED = 3
-
-
-class ItemSessionState(models.IntegerChoices):
-    IDLE_AND_REFUNDABLE = -4
-    IDLE = -3
-    REFUNDED = -2
-    CANCELLED = -1
-    NEW = 0
-    WAITING_FOR_PAYMENT = 1
-    WAITING_FOR_SIZE = 2
-    WAITING_FOR_NAME = 3
-    WAITING_FOR_ADDRESS = 4
-    SHIPPING_INFO_CONFIRMATION = 5
-    ALLOW_CONTACT_REQUESTED = 6
-    COMPLETED = 7
-
-    @classmethod
-    def active_states(cls):
-        return {
-            cls.NEW,
-            cls.WAITING_FOR_PAYMENT,
-            cls.WAITING_FOR_SIZE,
-            cls.WAITING_FOR_NAME,
-            cls.WAITING_FOR_ADDRESS,
-            cls.SHIPPING_INFO_CONFIRMATION,
-            cls.ALLOW_CONTACT_REQUESTED
-        }
-
-    @classmethod
-    def active_states(cls):
-        return {
-            cls.IDLE_AND_REFUNDABLE,
-            cls.WAITING_FOR_SIZE,
-            cls.WAITING_FOR_ADDRESS,
-            cls.WAITING_FOR_ADDRESS,
-            cls.WAITING_FOR_NAME,
-            cls.SHIPPING_INFO_CONFIRMATION
-        }
-
-
-class DropType(enum.Enum):
-    AIRDROP = 0
-    ITEM = 1
 
 
 class BaseDropSession:

--- a/src/mobot_client/logger.py
+++ b/src/mobot_client/logger.py
@@ -1,13 +1,8 @@
 # Copyright (c) 2021 MobileCoin. All rights reserved.
 
-import enum
+from django.db.models import IntegerChoices
 
-from mobot_client.models import Message
-
-
-class MessageDirection(enum.Enum):
-    RECEIVED = 0
-    SENT = 1
+from mobot_client.models import Message, MessageDirection
 
 
 class SignalMessenger:
@@ -23,7 +18,7 @@ class SignalMessenger:
             customer=customer,
             store=self.store,
             text=text,
-            direction=MessageDirection.SENT.value,
+            direction=MessageDirection.SENT,
         )
         sent_message.save()
         self.signal.send_message(source, text, attachments=attachments)
@@ -31,5 +26,5 @@ class SignalMessenger:
     @staticmethod
     def log_received(message, customer, store):
         incoming = Message(customer=customer, store=store, text=message.text,
-                           direction=MessageDirection.RECEIVED.value)
+                           direction=MessageDirection.RECEIVED)
         incoming.save()

--- a/src/mobot_client/mobot.py
+++ b/src/mobot_client/mobot.py
@@ -17,18 +17,15 @@ from mobot_client.models import (
     ChatbotSettings,
     Message,
     Order,
-    Sku,
+    Sku, SessionState, ItemSessionState, DropType, OrderStatus,
 )
 
 from mobot_client.drop_session import (
     BaseDropSession,
-    SessionState,
-    DropType,
-    ItemSessionState,
 )
 
 from mobot_client.air_drop_session import AirDropSession
-from mobot_client.item_drop_session import ItemDropSession, OrderStatus
+from mobot_client.item_drop_session import ItemDropSession
 from mobot_client.payments import Payments
 from mobot_client.chat_strings import ChatStrings
 from mobot_client.timeouts import Timeouts
@@ -122,8 +119,8 @@ class MOBot:
 
                 drop_session = DropSession.objects.get(
                     customer=customer,
-                    drop__drop_type=DropType.AIRDROP.value,
-                    state=SessionState.WAITING_FOR_BONUS_TRANSACTION.value,
+                    drop__drop_type=DropType.AIRDROP,
+                    state=SessionState.WAITING_FOR_BONUS_TRANSACTION,
                 )
             except DropSession.DoesNotExist:
                 pass
@@ -137,8 +134,8 @@ class MOBot:
             try:
                 drop_session = DropSession.objects.get(
                     customer=customer,
-                    drop__drop_type=DropType.ITEM.value,
-                    state=ItemSessionState.WAITING_FOR_PAYMENT.value,
+                    drop__drop_type=DropType.ITEM,
+                    state=ItemSessionState.WAITING_FOR_PAYMENT,
                 )
             except DropSession.DoesNotExist:
                 self.messenger.log_and_send_message(
@@ -177,7 +174,7 @@ class MOBot:
             skus = Sku.objects.filter(item=active_drop.item).order_by("sort_order")
             message_to_send = ""
             for sku in skus:
-                number_ordered = Order.objects.filter(sku=sku).exclude(status=OrderStatus.CANCELLED.value).count()
+                number_ordered = Order.objects.filter(sku=sku).exclude(status=OrderStatus.CANCELLED).count()
                 message_to_send += (
                     f"{sku.identifier} - {number_ordered} / {sku.quantity} ordered\n"
                 )
@@ -238,9 +235,9 @@ class MOBot:
             try:
                 active_drop_session = DropSession.objects.get(
                     customer=customer,
-                    drop__drop_type=DropType.AIRDROP.value,
-                    state__gte=SessionState.READY_TO_RECEIVE_INITIAL.value,
-                    state__lt=SessionState.COMPLETED.value,
+                    drop__drop_type=DropType.AIRDROP,
+                    state__gte=SessionState.READY_TO_RECEIVE_INITIAL,
+                    state__lt=SessionState.COMPLETED,
                 )
 
                 if active_drop_session.manual_override:
@@ -258,9 +255,9 @@ class MOBot:
             try:
                 active_drop_session = DropSession.objects.get(
                     customer=customer,
-                    drop__drop_type=DropType.ITEM.value,
-                    state__gte=ItemSessionState.WAITING_FOR_PAYMENT.value,
-                    state__lt=ItemSessionState.COMPLETED.value,
+                    drop__drop_type=DropType.ITEM,
+                    state__gte=ItemSessionState.WAITING_FOR_PAYMENT,
+                    state__lt=ItemSessionState.COMPLETED,
                 )
                 print(f"found active drop session in state {active_drop_session.state}")
                 if active_drop_session.manual_override:
@@ -301,13 +298,13 @@ class MOBot:
                 )
                 return
 
-            if active_drop.drop_type == DropType.AIRDROP.value:
+            if active_drop.drop_type == DropType.AIRDROP:
                 air_drop = AirDropSession(self.store, self.payments, self.messenger)
                 air_drop.handle_no_active_airdrop_drop_session(
                     customer, message, active_drop
                 )
 
-            if active_drop.drop_type == DropType.ITEM.value:
+            if active_drop.drop_type == DropType.ITEM:
                 item_drop = ItemDropSession(self.store, self.payments, self.messenger)
                 item_drop.handle_no_active_item_drop_session(
                     customer, message, active_drop

--- a/src/mobot_client/models.py
+++ b/src/mobot_client/models.py
@@ -85,7 +85,7 @@ class CustomerDropRefunds(models.Model):
     number_of_times_refunded = models.PositiveIntegerField(default=0)
 
 class DropSession(models.Model):
-    customer = models.ForeignKey(Customer, on_delete=models.CASCADE, related_name="drop_sessions")
+    customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     drop = models.ForeignKey(Drop, on_delete=models.CASCADE)
     state = models.IntegerField(default=0)
     manual_override = models.BooleanField(default=False)

--- a/src/mobot_client/models.py
+++ b/src/mobot_client/models.py
@@ -5,6 +5,7 @@ from django.db import models
 
 
 class SessionState(models.IntegerChoices):
+    OUT_OF_MOB = -2
     CANCELLED = -1
     READY_TO_RECEIVE_INITIAL = 0
     WAITING_FOR_BONUS_TRANSACTION = 1
@@ -161,51 +162,3 @@ class ChatbotSettings(SingletonModel):
 
     def __str__(self):
         return "Global settings"
-
-
-class ItemSessionState(models.IntegerChoices):
-    IDLE_AND_REFUNDABLE = -4
-    IDLE = -3
-    REFUNDED = -2
-    CANCELLED = -1
-    NEW = 0
-    WAITING_FOR_PAYMENT = 1
-    WAITING_FOR_SIZE = 2
-    WAITING_FOR_NAME = 3
-    WAITING_FOR_ADDRESS = 4
-    SHIPPING_INFO_CONFIRMATION = 5
-    ALLOW_CONTACT_REQUESTED = 6
-    COMPLETED = 7
-
-
-    @classmethod
-    def active_states(cls):
-        return {
-            cls.NEW,
-            cls.WAITING_FOR_PAYMENT,
-            cls.WAITING_FOR_SIZE,
-            cls.WAITING_FOR_NAME,
-            cls.WAITING_FOR_ADDRESS,
-            cls.SHIPPING_INFO_CONFIRMATION,
-            cls.ALLOW_CONTACT_REQUESTED
-        }
-
-    @classmethod
-    def refundable_states(cls):
-        return {
-            cls.IDLE_AND_REFUNDABLE,
-            cls.WAITING_FOR_SIZE,
-            cls.WAITING_FOR_ADDRESS,
-            cls.WAITING_FOR_ADDRESS,
-            cls.WAITING_FOR_NAME,
-            cls.SHIPPING_INFO_CONFIRMATION
-        }
-
-
-
-
-class OrderStatus(models.IntegerChoices):
-    STARTED = 0, 'started'
-    CONFIRMED = 1, 'confirmed'
-    SHIPPED = 2, 'shipped'
-    CANCELLED = 3, 'cancelled'

--- a/src/mobot_client/payments.py
+++ b/src/mobot_client/payments.py
@@ -3,10 +3,9 @@
 import mobilecoin as mc
 import time
 
-from mobot_client.drop_session import ItemSessionState
 from mobot_client.models import (
     Order,
-    Sku,
+    Sku, ItemSessionState,
 )
 from decimal import Decimal
 
@@ -181,7 +180,7 @@ class Payments:
                 ChatStrings.OUT_OF_STOCK_REFUND
             )
             self.send_mob_to_customer(customer, source, item_cost_mob, True)
-            drop_session.state = ItemSessionState.REFUNDED.value
+            drop_session.state = ItemSessionState.REFUNDED
             drop_session.save()
             return
 
@@ -190,7 +189,7 @@ class Payments:
         )
 
         self.messenger.log_and_send_message(customer, source, message_to_send)
-        drop_session.state = ItemSessionState.WAITING_FOR_SIZE.value
+        drop_session.state = ItemSessionState.WAITING_FOR_SIZE
         drop_session.save()
 
         return

--- a/src/mobot_client/timeouts.py
+++ b/src/mobot_client/timeouts.py
@@ -6,8 +6,7 @@ import time
 
 import mobilecoin as mc
 
-from mobot_client.models import DropSession, Customer, Message
-from mobot_client.drop_session import ItemSessionState
+from mobot_client.models import DropSession, Customer, Message, ItemSessionState
 from mobot_client.chat_strings import ChatStrings
 
 utc = pytz.UTC
@@ -29,21 +28,21 @@ class Timeouts:
     @staticmethod
     def customer_is_active(customer):
         session = DropSession.objects.filter(customer=customer).values('state').last()
-        if session is not None and session['state'] in ItemSessionState.active_states():
+        if session is not None and session.state in ItemSessionState.active_states():
             return True
         return False
 
     @staticmethod
     def customer_is_idle(customer):
         session = DropSession.objects.filter(customer=customer).values('state').last()
-        if session is not None and (session['state'] == ItemSessionState.IDLE.value or session['state'] == ItemSessionState.IDLE_AND_REFUNDABLE.value):
+        if session is not None and (session.state == ItemSessionState.IDLE or session.state == ItemSessionState.IDLE_AND_REFUNDABLE):
             return True
         return False
 
     @staticmethod
     def customer_needs_refund(customer):
         session = DropSession.objects.filter(customer=customer).values('state').last()
-        if session is not None and session['state'] in ItemSessionState.refundable_states():
+        if session is not None and session.state in ItemSessionState.refundable_states():
             return True
         return False
 
@@ -51,7 +50,7 @@ class Timeouts:
     def set_customer_idle(customer):
         session = DropSession.objects.filter(customer=customer).last()
         if session is not None and session.state in ItemSessionState.active_states():
-            session.state = ItemSessionState.IDLE.value
+            session.state = ItemSessionState.IDLE
             session.save()
 
     @staticmethod
@@ -59,23 +58,23 @@ class Timeouts:
         session = DropSession.objects.filter(customer=customer).last()
         if session is not None and session.state in ItemSessionState.active_states():
             if session.state in ItemSessionState.refundable_states():
-                session.state = ItemSessionState.IDLE_AND_REFUNDABLE.value
+                session.state = ItemSessionState.IDLE_AND_REFUNDABLE
             else:
-                session.state = ItemSessionState.IDLE.value
+                session.state = ItemSessionState.IDLE
             session.save()
 
     @staticmethod
     def set_customer_refunded(customer):
         session = DropSession.objects.filter(customer=customer).last()
-        if session is not None and (session.state in ItemSessionState.active_states() or session.state == ItemSessionState.IDLE.value):
-            session.state = ItemSessionState.REFUNDED.value
+        if session is not None and (session.state in ItemSessionState.active_states() or session.state == ItemSessionState.IDLE):
+            session.state = ItemSessionState.REFUNDED
             session.save()
 
     @staticmethod
     def set_customer_cancelled(customer):
         session = DropSession.objects.filter(customer=customer).last()
-        if session is not None and (session.state in ItemSessionState.active_states() or session.state == ItemSessionState.IDLE.value):
-            session.state = ItemSessionState.CANCELLED.value
+        if session is not None and (session.state in ItemSessionState.active_states() or session.state == ItemSessionState.IDLE):
+            session.state = ItemSessionState.CANCELLED
             session.save()
 
     def do_refund(self, customer):


### PR DESCRIPTION
Soundtrack of this PR: [E-40 - Choices (Yup)](https://www.youtube.com/watch?v=bRChz-OYi9o)

### Motivation

Currently, we're using plain enums instead of the magical Django-provided derivative, models.IntegerChoices. To improve the admin interface and use fun features like enum labels, we're switching these out.

### In this PR

Changes all enum.Enum classes used in models to django's models.IntegerChoices

Addresses [Change enum.Enum classes to Django models.IntegerChoices](https://app.asana.com/0/1200175610893108/1200767239741394)
### Future Work

* More model cleanups as I come across them

